### PR TITLE
Remove unsupported `U` file mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of qgispluginreleaser
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Use file mode ``r`` instead of ``rU`` to support Python 3.11+.
 
 
 1.1 (2020-05-25)

--- a/qgispluginreleaser/entry_point.py
+++ b/qgispluginreleaser/entry_point.py
@@ -67,7 +67,7 @@ def fix_version(context):
     metadata_file = find_metadata_file()
     if not metadata_file:
         return
-    lines = codecs.open(metadata_file, 'rU', 'utf-8').readlines()
+    lines = codecs.open(metadata_file, 'r', 'utf-8').readlines()
     for index, line in enumerate(lines):
         if line.startswith('version'):
             new_line = 'version=%s\n' % context['new_version']


### PR DESCRIPTION
Currently, the metadata file is opened in the `rU` mode. This has been deprecated since Python 3.0, in which the `r` mode has been changed to do the same as `rU` previously did. In Python 3.11, the `U` mode was removed, causing the following error to appear:
```
Traceback (most recent call last):
  File "/home/eli/Programs/threedi-api-qgis-client/venv/bin/fullrelease", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/zest/releaser/fullrelease.py", line 23, in main
    prereleaser.run()
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/zest/releaser/baserelease.py", line 426, in run
    self._run_hooks("middle")
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/zest/releaser/baserelease.py", line 421, in _run_hooks
    utils.run_hooks(self.zest_releaser_config, which_releaser, when, self.data)
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/zest/releaser/utils.py", line 599, in run_hooks
    run_entry_points(which_releaser, when, data)
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/zest/releaser/utils.py", line 615, in run_entry_points
    plugin(data)
  File "/home/eli/Programs/threedi-api-qgis-client/venv/lib/python3.12/site-packages/qgispluginreleaser/entry_point.py", line 70, in fix_version
    lines = codecs.open(metadata_file, 'rU', 'utf-8').readlines()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 918, in open
ValueError: invalid mode: 'rUb'
```
This PR uses the `r` mode instead.
See also:
- https://github.com/eddie3/gogrepo/issues/69
- https://stackoverflow.com/questions/56791545/what-is-the-non-deprecated-version-of-open-u-mode
- the list of changes for 3.11 in https://docs.python.org/3/library/functions.html#open